### PR TITLE
remove use of deprecated User.getMultipleUserFields

### DIFF
--- a/library.js
+++ b/library.js
@@ -95,7 +95,7 @@
 
 			uids = uids.slice(0, count);
 
-			user.getMultipleUserFields(uids, ['uid', 'username', 'userslug', 'picture'], function(err, users) {
+			user.getUsersFields(uids, ['uid', 'username', 'userslug', 'picture'], function(err, users) {
 				if (err) {
 					return callback(err);
 				}


### PR DESCRIPTION
@barisusakli Fixes nodebb/nodebb#3728

[CLA](http://gist.github.com/psychobunny/65946d7aa8854b12fab9) Accepted.
Dustin Falgout <dustin@falgout.us>