### PR TITLE
Use Teaser-User-Image on Recent Topics

### DIFF
--- a/public/templates/partials/topics_teaser.tpl
+++ b/public/templates/partials/topics_teaser.tpl
@@ -1,0 +1,18 @@
+<!-- BEGIN topics -->
+<li class="clearfix widget-topics">
+	<a href="<!-- IF topics.teaser.user.userslug -->{relative_path}/user/{topics.teaser.user.userslug}<!-- ELSE -->#<!-- ENDIF topics.teaser.user.userslug -->">
+		<!-- IF topics.teaser.user.picture -->
+		<img title="{topics.teaser.user.username}" class="avatar avatar-sm not-responsive" src="{topics.teaser.user.picture}" />
+		<!-- ELSE -->
+		<div class="avatar avatar-sm not-responsive" style="background-color: {topics.teaser.user.icon:bgColor};">{topics.teaser.user.icon:text}</div>
+		<!-- ENDIF topics.t.picture -->
+	</a>
+
+	<p>
+		<a href="{relative_path}/topic/{topics.slug}">{topics.title}</a>
+	</p>
+	<span class="pull-right post-preview-footer">
+		<span class="timeago" title="{topics.lastposttimeISO}"></span>
+	</span>
+</li>
+<!-- END topics -->

--- a/public/templates/widgets/recenttopics.tpl
+++ b/public/templates/widgets/recenttopics.tpl
@@ -1,6 +1,6 @@
 <div class="recent-replies">
 	<ul id="recent_topics" data-numtopics="{numTopics}">
-	<!-- IMPORT partials/topics.tpl -->
+	<!-- IMPORT partials/topics_teaser.tpl -->
 	</ul>
 </div>
 


### PR DESCRIPTION
Fixes #31
The recent Topics Widget orders Topics by their last post, not their creation date.
Therefore the image should also be the image of the last poster.