### PR TITLE
fix parent require method using absolute path with  nbbRequire

### DIFF
--- a/lib/nbbRequire.js
+++ b/lib/nbbRequire.js
@@ -1,0 +1,6 @@
+var path = require('path');
+var nconf = require.main.require('nconf');
+
+module.exports = modulePath => {
+	return require(path.join(nconf.get('base_dir'), modulePath));
+};

--- a/library.js
+++ b/library.js
@@ -5,14 +5,16 @@ var nconf = require.main.require('nconf');
 var validator = require.main.require('validator');
 var benchpressjs = require.main.require('benchpressjs');
 
-var db = require.main.require('./src/database');
-var categories = require.main.require('./src/categories');
-var user = require.main.require('./src/user');
-var plugins = require.main.require('./src/plugins');
-var topics = require.main.require('./src/topics');
-var posts = require.main.require('./src/posts');
-var groups = require.main.require('./src/groups');
-var utils = require.main.require('./src/utils');
+var nbbRequire = require('./lib/nbbRequire');
+
+var db = nbbRequire('./src/database');
+var categories = nbbRequire('./src/categories');
+var user = nbbRequire('./src/user');
+var plugins = nbbRequire('./src/plugins');
+var topics = nbbRequire('./src/topics');
+var posts = nbbRequire('./src/posts');
+var groups = nbbRequire('./src/groups');
+var utils = nbbRequire('./src/utils');
 
 var app;
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,12 @@
     "name": "psychobunny",
     "email": "psycho.bunny@hotmail.com"
   },
+  "contributors": [
+    {
+      "name": "bonaccorsop",
+      "email": "bonaccorso.p@gmail.com"
+    }
+  ],
   "license": "BSD-2-Clause",
   "bugs": {
     "url": "https://github.com/psychobunny/nodebb-widget-essentials/issues"


### PR DESCRIPTION
This fix the warning in NodeBB 1.10.* "warn: [plugins/require] please update module.parent.require" for linked npm package (development mode) and for npm registry imported package (classic install)